### PR TITLE
Improve mobile layout for prose content and code blocks

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -139,6 +139,31 @@
   display: inline;
 }
 
-.token.table {
-  display: inline;
+/* Mobile-friendly code block adjustments */
+pre[class*='language-'] {
+  @apply text-sm leading-relaxed rounded-lg p-3 sm:p-4;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (min-width: 640px) {
+  pre[class*='language-'] {
+    font-size: 0.9375rem;
+  }
+}
+
+/* Code title mobile adjustments */
+.remark-code-title {
+  @apply text-xs sm:text-sm px-3 sm:px-5 py-2 sm:py-3;
+}
+
+/* Line number mobile adjustments */
+.line-number::before {
+  @apply text-xs sm:text-sm;
+}
+
+/* Code line mobile padding */
+.code-line {
+  @apply -mx-3 sm:-mx-4 pl-3 sm:pl-4 pr-3 sm:pr-4;
 }

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -27,3 +27,68 @@ input:-webkit-autofill,
 input:-webkit-autofill:focus {
   transition: background-color 600000s 0s, color 600000s 0s;
 }
+
+/* Mobile-friendly prose adjustments */
+.prose {
+  @apply text-base leading-relaxed;
+}
+
+@media (min-width: 640px) {
+  .prose {
+    @apply text-lg;
+  }
+}
+
+/* Mobile-friendly code blocks */
+.prose pre {
+  @apply text-sm leading-relaxed overflow-x-auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (min-width: 640px) {
+  .prose pre {
+    @apply text-base;
+  }
+}
+
+/* Inline code mobile adjustments */
+.prose code:not(pre code) {
+  @apply text-sm break-words;
+  word-break: break-word;
+}
+
+@media (min-width: 640px) {
+  .prose code:not(pre code) {
+    @apply text-base;
+  }
+}
+
+/* Better mobile spacing for headings */
+.prose h1 {
+  @apply text-2xl sm:text-3xl;
+}
+
+.prose h2 {
+  @apply text-xl sm:text-2xl;
+}
+
+.prose h3 {
+  @apply text-lg sm:text-xl;
+}
+
+/* Mobile list spacing */
+.prose ul,
+.prose ol {
+  @apply pl-4 sm:pl-6;
+}
+
+/* Mobile blockquote */
+.prose blockquote {
+  @apply pl-3 sm:pl-4 text-base sm:text-lg;
+}
+
+/* Mobile table scroll */
+.prose table {
+  @apply block overflow-x-auto;
+  -webkit-overflow-scrolling: touch;
+}

--- a/layouts/AuthorLayout.tsx
+++ b/layouts/AuthorLayout.tsx
@@ -40,7 +40,7 @@ export default function AuthorLayout({ children, content }: Props) {
               <SocialIcon kind="twitter" href={twitter} />
             </div>
           </div>
-          <div className="prose max-w-none pt-8 pb-8 dark:prose-dark xl:col-span-2">{children}</div>
+          <div className="prose prose-base sm:prose-lg max-w-none pt-8 pb-8 dark:prose-dark xl:col-span-2">{children}</div>
         </div>
       </div>
     </>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -95,7 +95,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
               </dd>
             </dl>
             <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
-              <div className="prose max-w-none pt-10 pb-8 dark:prose-dark">{children}</div>
+              <div className="prose prose-base sm:prose-lg max-w-none pt-10 pb-8 dark:prose-dark">{children}</div>
               <div className="pt-6 pb-6 text-sm text-gray-700 dark:text-gray-300">
                 <Link href={discussUrl(path)} rel="nofollow">
                   Discuss on Twitter

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -45,7 +45,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
           </header>
           <div className="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 dark:divide-gray-700 xl:divide-y-0">
             <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
-              <div className="prose max-w-none pt-10 pb-8 dark:prose-dark">{children}</div>
+              <div className="prose prose-base sm:prose-lg max-w-none pt-10 pb-8 dark:prose-dark">{children}</div>
             </div>
             {siteMetadata.comments && (
               <div className="pt-6 pb-6 text-center text-gray-700 dark:text-gray-300" id="comment">


### PR DESCRIPTION
- Add responsive font sizes for prose text (base on mobile, lg on desktop)
- Improve code block readability with mobile-friendly font sizes and padding
- Add horizontal scroll support for code blocks and tables on mobile
- Adjust heading sizes for better mobile display
- Fix inline code wrapping on mobile screens

https://claude.ai/code/session_012Z13ufNsmUA5gsXiQTnz55