### PR TITLE
Add glass morphism background to content area

### DIFF
--- a/components/LayoutWrapper.tsx
+++ b/components/LayoutWrapper.tsx
@@ -54,7 +54,11 @@ const LayoutWrapper = ({ children }: Props) => {
 
         <div className={`${inter.className} relative flex h-screen flex-col justify-between font-sans`}>
           <Header />
-          <main className="mb-auto">{children}</main>
+          <main className="mb-auto">
+            <div className="rounded-2xl border border-white/10 bg-black/50 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8">
+              {children}
+            </div>
+          </main>
           <Footer />
         </div>
       </SectionContainer>


### PR DESCRIPTION
Add semi-transparent black background with backdrop blur effect to the
main content area for improved readability while maintaining the
stylish dark aesthetic.

https://claude.ai/code/session_01Bgud3oab9Z4VGCcmHsrt5C