### PR TITLE
Move glassmorphism effect to PostLayout/PostSimple article elements

### DIFF
--- a/components/LayoutWrapper.tsx
+++ b/components/LayoutWrapper.tsx
@@ -55,9 +55,7 @@ const LayoutWrapper = ({ children }: Props) => {
         <div className={`${inter.className} relative flex h-screen flex-col justify-between font-sans`}>
           <Header />
           <main className="mb-auto">
-            <div className="rounded-2xl border border-white/10 bg-black/50 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8">
-              {children}
-            </div>
+            {children}
           </main>
           <Footer />
         </div>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -39,7 +39,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
     <SectionContainer>
       <BlogSEO url={`${siteMetadata.siteUrl}/${path}`} authorDetails={authorDetails} {...content} />
       <ScrollTopAndComment />
-      <article>
+      <article className="rounded-2xl border border-white/10 bg-black/50 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8">
         <div className="xl:divide-y xl:divide-gray-200 xl:dark:divide-gray-700">
           <header className="pt-6 xl:pb-6">
             <div className="space-y-1 text-center">

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -26,7 +26,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
     <SectionContainer>
       <BlogSEO url={`${siteMetadata.siteUrl}/${path}`} {...content} />
       <ScrollTopAndComment />
-      <article>
+      <article className="rounded-2xl border border-white/10 bg-black/50 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8">
         <div>
           <header>
             <div className="space-y-1 border-b border-gray-200 pb-10 text-center dark:border-gray-700">


### PR DESCRIPTION
LayoutWrapper の main 全体ラッパーからグラスモーフィズムを外し、
PostLayout と PostSimple の article 要素に直接適用することで
ブログ記事コンテンツ背景に効果が明確に見えるようにした。

https://claude.ai/code/session_01WDDUUg8PZoqnD5toupxJuK