### PR TITLE
Add JA/EN language switcher using Google Translate

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import headerNavLinks from '@/data/headerNavLinks'
 import Link from './Link'
 import MobileNav from './MobileNav'
 import ThemeSwitch from './ThemeSwitch'
+import LanguageSwitcher from './LanguageSwitcher'
 // import Typical from 'react-typical'
 import { TypeAnimation } from 'react-type-animation'
 
@@ -43,6 +44,7 @@ const Header = () => {
             </Link>
           ))}
         </div>
+        <LanguageSwitcher />
         <ThemeSwitch />
         <MobileNav />
       </div>

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react'
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    google: any
+    googleTranslateElementInit: () => void
+  }
+}
+
+const LanguageSwitcher = () => {
+  const [mounted, setMounted] = useState(false)
+  const [currentLang, setCurrentLang] = useState<'ja' | 'en'>('ja')
+
+  useEffect(() => {
+    setMounted(true)
+
+    // Detect existing translation state from cookie
+    if (document.cookie.includes('googtrans=/ja/en')) {
+      setCurrentLang('en')
+    }
+
+    // Define callback for Google Translate initialization
+    window.googleTranslateElementInit = () => {
+      new window.google.translate.TranslateElement(
+        {
+          pageLanguage: 'ja',
+          includedLanguages: 'en',
+          autoDisplay: false,
+          layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+        },
+        'google_translate_element'
+      )
+    }
+
+    // Load Google Translate script if not already present
+    if (!document.getElementById('google-translate-script')) {
+      const script = document.createElement('script')
+      script.id = 'google-translate-script'
+      script.src =
+        '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit'
+      script.async = true
+      document.body.appendChild(script)
+    }
+  }, [])
+
+  const switchToEnglish = useCallback(() => {
+    const select = document.querySelector('.goog-te-combo') as HTMLSelectElement
+    if (select) {
+      select.value = 'en'
+      select.dispatchEvent(new Event('change'))
+      setCurrentLang('en')
+    }
+  }, [])
+
+  const switchToJapanese = useCallback(() => {
+    // Clear googtrans cookies
+    document.cookie = 'googtrans=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
+    document.cookie =
+      'googtrans=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.' +
+      window.location.hostname
+
+    // Try to click the "Show original" button in the Google Translate banner
+    const banner = document.querySelector('.goog-te-banner-frame') as HTMLIFrameElement
+    if (banner) {
+      const innerDoc = banner.contentDocument || banner.contentWindow?.document
+      if (innerDoc) {
+        const restoreBtn = innerDoc.querySelector('.goog-close-link') as HTMLElement
+        if (restoreBtn) {
+          restoreBtn.click()
+          setCurrentLang('ja')
+          return
+        }
+      }
+    }
+
+    // Fallback: reload page to restore original language
+    setCurrentLang('ja')
+    window.location.reload()
+  }, [])
+
+  const handleClick = useCallback(
+    (lang: 'ja' | 'en') => {
+      if (lang === currentLang) return
+      if (lang === 'en') {
+        switchToEnglish()
+      } else {
+        switchToJapanese()
+      }
+    },
+    [currentLang, switchToEnglish, switchToJapanese]
+  )
+
+  if (!mounted) return null
+
+  return (
+    <>
+      <div id="google_translate_element" className="hidden" />
+      <div
+        className="ml-1 mr-1 flex items-center rounded p-1 text-sm font-medium sm:ml-4"
+        role="radiogroup"
+        aria-label="Language switcher"
+      >
+        <button
+          role="radio"
+          aria-checked={currentLang === 'ja'}
+          className={`rounded px-1.5 py-0.5 transition-colors ${
+            currentLang === 'ja'
+              ? 'bg-gray-600 text-white'
+              : 'text-gray-400 hover:text-gray-200'
+          }`}
+          onClick={() => handleClick('ja')}
+        >
+          JA
+        </button>
+        <span className="mx-0.5 text-gray-500">/</span>
+        <button
+          role="radio"
+          aria-checked={currentLang === 'en'}
+          className={`rounded px-1.5 py-0.5 transition-colors ${
+            currentLang === 'en'
+              ? 'bg-gray-600 text-white'
+              : 'text-gray-400 hover:text-gray-200'
+          }`}
+          onClick={() => handleClick('en')}
+        >
+          EN
+        </button>
+      </div>
+    </>
+  )
+}
+
+export default LanguageSwitcher

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -92,3 +92,24 @@ input:-webkit-autofill:focus {
   @apply block overflow-x-auto;
   -webkit-overflow-scrolling: touch;
 }
+
+/* Hide Google Translate default UI */
+.goog-te-banner-frame {
+  display: none !important;
+}
+
+body {
+  top: 0 !important;
+}
+
+.goog-te-gadget {
+  font-size: 0 !important;
+}
+
+.skiptranslate {
+  display: none !important;
+}
+
+#google_translate_element {
+  display: none !important;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -7,13 +7,13 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app translate.google.com translate.googleapis.com;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src 'none';
   connect-src *;
-  font-src 'self';
-  frame-src giscus.app
+  font-src 'self' fonts.gstatic.com;
+  frame-src giscus.app translate.google.com
 `
 
 const securityHeaders = [


### PR DESCRIPTION
- Create LanguageSwitcher component with JA/EN toggle buttons
- Integrate Google Translate API for automatic page translation
- Update CSP to allow Google Translate domains
- Hide default Google Translate UI with custom CSS
- Place switcher in header next to theme toggle

https://claude.ai/code/session_01FiHNikuXEP3CtVhkAK2gpV