### PR TITLE
Fix JA/EN language toggle: EN button not working

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -45,12 +45,17 @@ const LanguageSwitcher = () => {
   }, [])
 
   const switchToEnglish = useCallback(() => {
-    const select = document.querySelector('.goog-te-combo') as HTMLSelectElement
-    if (select) {
-      select.value = 'en'
-      select.dispatchEvent(new Event('change'))
-      setCurrentLang('en')
+    const tryTranslate = (retries: number) => {
+      const select = document.querySelector('.goog-te-combo') as HTMLSelectElement
+      if (select) {
+        select.value = 'en'
+        select.dispatchEvent(new Event('change'))
+        setCurrentLang('en')
+      } else if (retries > 0) {
+        setTimeout(() => tryTranslate(retries - 1), 500)
+      }
     }
+    tryTranslate(10)
   }, [])
 
   const switchToJapanese = useCallback(() => {
@@ -95,7 +100,7 @@ const LanguageSwitcher = () => {
 
   return (
     <>
-      <div id="google_translate_element" className="hidden" />
+      <div id="google_translate_element" />
       <div
         className="ml-1 mr-1 flex items-center rounded p-1 text-sm font-medium sm:ml-4"
         role="radiogroup"

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -111,5 +111,9 @@ body {
 }
 
 #google_translate_element {
-  display: none !important;
+  position: absolute !important;
+  left: -9999px !important;
+  top: -9999px !important;
+  height: 0 !important;
+  overflow: hidden !important;
 }


### PR DESCRIPTION
Root causes:
- #google_translate_element was hidden with display:none (both CSS class
  and !important rule), preventing Google Translate from initializing its
  widget (.goog-te-combo select element)
- switchToEnglish() silently failed when the select element was missing,
  with no retry mechanism for async script loading

Changes:
- Replace display:none on #google_translate_element with offscreen
  positioning so the widget can initialize in the DOM
- Remove className="hidden" from the container div
- Add retry mechanism (up to 10 attempts, 500ms interval) in
  switchToEnglish() to wait for Google Translate widget readiness

https://claude.ai/code/session_01VBcYsdiJPqhNtYnoXAinSw