### PR TITLE
Add aurora gradient background for light mode and fix all light mode readability

### DIFF
--- a/components/BitcoinDonation.tsx
+++ b/components/BitcoinDonation.tsx
@@ -26,7 +26,7 @@ function CopyButton({ text }: { text: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="shrink-0 rounded bg-gray-700 px-2 py-1 text-xs text-gray-300 transition hover:bg-gray-600"
+      className="shrink-0 rounded bg-gray-200 px-2 py-1 text-xs text-gray-700 transition hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
     >
       {copied ? 'Copied!' : 'Copy'}
     </button>
@@ -91,7 +91,7 @@ export default function BitcoinDonation() {
     <div className="py-6">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="inline-flex items-center gap-2 rounded-lg border border-orange-500/30 bg-orange-500/10 px-4 py-2 text-sm font-medium text-orange-400 transition hover:bg-orange-500/20 hover:text-orange-300"
+        className="inline-flex items-center gap-2 rounded-lg border border-orange-500/30 bg-orange-500/10 px-4 py-2 text-sm font-medium text-orange-600 transition hover:bg-orange-500/20 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
       >
         <BitcoinSvg className="h-5 w-5 fill-current" />
         暗号通貨で寄付する
@@ -99,7 +99,7 @@ export default function BitcoinDonation() {
       </button>
 
       {isOpen && (
-        <div className="mt-4 space-y-4 rounded-lg border border-gray-700 bg-gray-800/50 p-4">
+        <div className="mt-4 space-y-4 rounded-lg border border-gray-200 bg-white/80 backdrop-blur-sm p-4 dark:border-gray-700 dark:bg-gray-800/50">
           {/* Bitcoin On-chain */}
           {btcAddress && (
             <div>
@@ -108,7 +108,7 @@ export default function BitcoinDonation() {
                 Bitcoin (On-chain)
               </div>
               <div className="flex items-center gap-2">
-                <code className="min-w-0 overflow-x-auto rounded bg-gray-900 px-3 py-2 text-xs text-gray-300">
+                <code className="min-w-0 overflow-x-auto rounded bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-300">
                   {btcAddress}
                 </code>
                 <CopyButton text={btcAddress} />
@@ -130,7 +130,7 @@ export default function BitcoinDonation() {
                 Lightning Network
               </div>
               <div className="flex items-center gap-2">
-                <code className="min-w-0 overflow-x-auto rounded bg-gray-900 px-3 py-2 text-xs text-gray-300">
+                <code className="min-w-0 overflow-x-auto rounded bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-300">
                   {lnAddress}
                 </code>
                 <CopyButton text={lnAddress} />
@@ -155,7 +155,7 @@ export default function BitcoinDonation() {
                 Ethereum / Polygon / Arbitrum / Base / Hyperliquid
               </p>
               <div className="flex items-center gap-2">
-                <code className="min-w-0 overflow-x-auto rounded bg-gray-900 px-3 py-2 text-xs text-gray-300">
+                <code className="min-w-0 overflow-x-auto rounded bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-300">
                   {evmAddress}
                 </code>
                 <CopyButton text={evmAddress} />
@@ -172,7 +172,7 @@ export default function BitcoinDonation() {
                 SOL (Solana)
               </div>
               <div className="flex items-center gap-2">
-                <code className="min-w-0 overflow-x-auto rounded bg-gray-900 px-3 py-2 text-xs text-gray-300">
+                <code className="min-w-0 overflow-x-auto rounded bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-300">
                   {solAddress}
                 </code>
                 <CopyButton text={solAddress} />
@@ -180,7 +180,7 @@ export default function BitcoinDonation() {
             </div>
           )}
 
-          <p className="border-t border-gray-700 pt-3 text-xs text-gray-500">
+          <p className="border-t border-gray-200 pt-3 dark:border-gray-700 text-xs text-gray-500">
             これは任意の寄付であり、対価・見返りは発生しません。ご支援ありがとうございます。
           </p>
         </div>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -6,7 +6,7 @@ const Card = ({ title, description, imgSrc, href }) => (
     <div
       className={`${
         imgSrc && 'h-full'
-      }  overflow-hidden rounded-md border-2 border-gray-700 border-opacity-60 dark:border-gray-700`}
+      }  overflow-hidden rounded-md border-2 border-gray-200 border-opacity-60 dark:border-gray-700`}
     >
       {imgSrc &&
         (href ? (
@@ -38,7 +38,7 @@ const Card = ({ title, description, imgSrc, href }) => (
             title
           )}
         </h2>
-        <p className="prose mb-3 max-w-none text-gray-400 dark:text-gray-400">{description}</p>
+        <p className="prose mb-3 max-w-none text-gray-600 dark:text-gray-400">{description}</p>
         {href && (
           <Link
             href={href}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,14 +14,14 @@ export default function Footer() {
           <SocialIcon kind="linkedin" href={siteMetadata.linkedin} size={6} />
           <SocialIcon kind="twitter" href={siteMetadata.twitter} size={6} />
         </div>
-        <div className="mb-2 flex space-x-2 text-sm text-gray-200 dark:text-gray-200">
+        <div className="mb-2 flex space-x-2 text-sm text-gray-600 dark:text-gray-200">
           <div>{siteMetadata.author}</div>
           <div>{` • `}</div>
           <div>{`© ${new Date().getFullYear()}`}</div>
           <div>{` • `}</div>
           <Link href="/">{siteMetadata.title}</Link>
         </div>
-        <div className="mb-8 text-sm text-gray-400 dark:text-gray-400">
+        <div className="mb-8 text-sm text-gray-500 dark:text-gray-400">
           <Link href="https://distrikt.app/u/GypsyRM">
             Access to distrikt
           </Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -37,7 +37,7 @@ const Header = () => {
             <Link
               key={link.title}
               href={link.href}
-              className="p-1 font-medium text-gray-100 dark:text-gray-100 sm:p-4"
+              className="p-1 font-medium text-gray-700 hover:text-gray-900 dark:text-gray-100 dark:hover:text-white sm:p-4"
             >
               {link.title}
             </Link>

--- a/components/LayoutWrapper.tsx
+++ b/components/LayoutWrapper.tsx
@@ -1,8 +1,9 @@
 import { Inter } from '@next/font/google'
 import SectionContainer from './SectionContainer'
 import Footer from './Footer'
-import { ReactNode, useEffect, useRef } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import Header from './Header'
+import { useTheme } from 'next-themes'
 
 interface Props {
   children: ReactNode
@@ -14,14 +15,22 @@ const inter = Inter({
 
 const LayoutWrapper = ({ children }: Props) => {
   const canvasRef = useRef(null)
+  const { resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  const isDark = mounted && resolvedTheme === 'dark'
 
   useEffect(() => {
+    if (!isDark || !canvasRef.current) return
+
     const s = window.screen
     const canvas = canvasRef.current
     const ctx = canvas.getContext('2d')
 
-    const width = (canvas.width = s.width)
-    const height = (canvas.height = s.height)
+    canvas.width = s.width
+    canvas.height = s.height
 
     const matrix = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789#$%^&*()*&^%'.split('')
 
@@ -45,12 +54,36 @@ const LayoutWrapper = ({ children }: Props) => {
 
     const interval = setInterval(draw, 35)
     return () => clearInterval(interval)
-  }, [])
+  }, [isDark])
 
   return (
     <>
-      <SectionContainer style={{background: 'none' }}>
-      <canvas ref={canvasRef} className="fixed left-0 top-0 h-screen w-screen bg-black" />
+      <SectionContainer style={{ background: 'none' }}>
+        {/* Dark mode: Matrix background */}
+        {isDark && (
+          <canvas ref={canvasRef} className="fixed left-0 top-0 h-screen w-screen bg-black" />
+        )}
+
+        {/* Light mode: Aurora gradient background */}
+        {mounted && !isDark && (
+          <div className="fixed inset-0 bg-gradient-to-br from-gray-50 via-white to-gray-100">
+            <div
+              className="absolute -top-40 -right-40 h-[500px] w-[500px] animate-blob rounded-full bg-sky-200 opacity-40 mix-blend-multiply blur-3xl"
+            />
+            <div
+              className="absolute top-40 -left-20 h-[500px] w-[500px] animate-blob rounded-full bg-violet-200 opacity-40 mix-blend-multiply blur-3xl"
+              style={{ animationDelay: '2s' }}
+            />
+            <div
+              className="absolute -bottom-40 left-1/3 h-[500px] w-[500px] animate-blob rounded-full bg-pink-200 opacity-30 mix-blend-multiply blur-3xl"
+              style={{ animationDelay: '4s' }}
+            />
+            <div
+              className="absolute top-1/2 right-1/4 h-[400px] w-[400px] animate-blob rounded-full bg-emerald-100 opacity-30 mix-blend-multiply blur-3xl"
+              style={{ animationDelay: '6s' }}
+            />
+          </div>
+        )}
 
         <div className={`${inter.className} relative flex h-screen flex-col justify-between font-sans`}>
           <Header />

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -28,7 +28,7 @@ const MobileNav = () => {
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
           fill="currentColor"
-          className="text-gray-100 dark:text-gray-100"
+          className="text-gray-700 dark:text-gray-100"
         >
           <path
             fillRule="evenodd"
@@ -38,7 +38,7 @@ const MobileNav = () => {
         </svg>
       </button>
       <div
-        className={`fixed top-0 left-0 z-10 h-full w-full transform bg-gray-200 opacity-95 duration-300 ease-in-out dark:bg-gray-800 ${
+        className={`fixed top-0 left-0 z-10 h-full w-full transform bg-white opacity-95 duration-300 ease-in-out dark:bg-gray-800 ${
           navShow ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
@@ -52,7 +52,7 @@ const MobileNav = () => {
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
               fill="currentColor"
-              className="text-gray-100 dark:text-gray-100"
+              className="text-gray-700 dark:text-gray-100"
             >
               <path
                 fillRule="evenodd"
@@ -67,7 +67,7 @@ const MobileNav = () => {
             <div key={link.title} className="px-12 py-4">
               <Link
                 href={link.href}
-                className="text-2xl font-bold tracking-widest text-gray-100 dark:text-gray-100"
+                className="text-2xl font-bold tracking-widest text-gray-800 dark:text-gray-100"
                 onClick={onToggleNav}
               >
                 {link.title}

--- a/components/PageTitle.tsx
+++ b/components/PageTitle.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function PageTitle({ children }: Props) {
   return (
-    <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-100 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14">
+    <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14">
       {children}
     </h1>
   )

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -10,7 +10,7 @@ const ProjectCard = ({ title, description, imgSrc, href, category }: ProjectCard
 
   return (
     <div className="group w-full">
-      <div className="h-full overflow-hidden rounded-xl border border-gray-700/50 bg-gray-800/30 transition-all duration-300 hover:border-primary-500/50 hover:bg-gray-800/50 hover:shadow-lg hover:shadow-primary-500/10">
+      <div className="h-full overflow-hidden rounded-xl border border-gray-200 bg-white/60 backdrop-blur-sm transition-all duration-300 hover:border-primary-500/50 hover:bg-white/80 hover:shadow-lg hover:shadow-primary-500/10 dark:border-gray-700/50 dark:bg-gray-800/30 dark:hover:bg-gray-800/50">
         {/* モバイル: 横型レイアウト / PC: 縦型レイアウト */}
         <div className="flex flex-row sm:flex-col">
           {/* 画像部分 */}
@@ -27,7 +27,7 @@ const ProjectCard = ({ title, description, imgSrc, href, category }: ProjectCard
                       height={225}
                     />
                     {/* オーバーレイ */}
-                    <div className="absolute inset-0 bg-gradient-to-t from-gray-900/60 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
                   </div>
                 </Link>
               ) : (
@@ -60,7 +60,7 @@ const ProjectCard = ({ title, description, imgSrc, href, category }: ProjectCard
             </div>
 
             {/* タイトル */}
-            <h3 className="mb-1 line-clamp-2 text-sm font-bold leading-tight text-gray-100 sm:mb-2 sm:text-lg">
+            <h3 className="mb-1 line-clamp-2 text-sm font-bold leading-tight text-gray-900 sm:mb-2 sm:text-lg dark:text-gray-100">
               {href ? (
                 <Link
                   href={href}
@@ -75,7 +75,7 @@ const ProjectCard = ({ title, description, imgSrc, href, category }: ProjectCard
             </h3>
 
             {/* 説明文 */}
-            <p className="mb-2 line-clamp-2 flex-1 text-xs leading-relaxed text-gray-400 sm:mb-3 sm:line-clamp-3 sm:text-sm">
+            <p className="mb-2 line-clamp-2 flex-1 text-xs leading-relaxed text-gray-600 sm:mb-3 sm:line-clamp-3 sm:text-sm dark:text-gray-400">
               {description}
             </p>
 
@@ -84,7 +84,7 @@ const ProjectCard = ({ title, description, imgSrc, href, category }: ProjectCard
               <div className="mt-auto">
                 <Link
                   href={href}
-                  className="inline-flex items-center gap-1 text-xs font-medium text-primary-400 transition-colors hover:text-primary-300 sm:text-sm"
+                  className="inline-flex items-center gap-1 text-xs font-medium text-primary-500 transition-colors hover:text-primary-600 sm:text-sm dark:text-primary-400 dark:hover:text-primary-300"
                   aria-label={`Link to ${title}`}
                 >
                   詳細を見る

--- a/components/ScrollTopAndComment.tsx
+++ b/components/ScrollTopAndComment.tsx
@@ -28,7 +28,7 @@ const ScrollTopAndComment = () => {
         <button
           aria-label="Scroll To Comment"
           onClick={handleScrollToComment}
-          className="rounded-full bg-gray-200 p-2 text-gray-200 transition-all hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
+          className="rounded-full bg-gray-200 p-2 text-gray-600 transition-all hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
         >
           <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
             <path
@@ -42,7 +42,7 @@ const ScrollTopAndComment = () => {
       <button
         aria-label="Scroll To Top"
         onClick={handleScrollTop}
-        className="rounded-full bg-gray-700 p-2 text-gray-400 transition-all hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
+        className="rounded-full bg-gray-200 p-2 text-gray-600 transition-all hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
       >
         <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
           <path

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -9,7 +9,7 @@ const Tag = ({ text }: Props) => {
   return (
     <Link
       href={`/tags/${kebabCase(text)}`}
-      className="rounded-full bg-gray-700/50 px-2.5 py-0.5 text-xs font-medium text-primary-400 transition-colors hover:bg-gray-700 hover:text-primary-300"
+      className="rounded-full bg-gray-200 px-2.5 py-0.5 text-xs font-medium text-primary-600 transition-colors hover:bg-gray-300 hover:text-primary-700 dark:bg-gray-700/50 dark:text-primary-400 dark:hover:bg-gray-700 dark:hover:text-primary-300"
     >
       {text.split(' ').join('-')}
     </Link>

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -18,7 +18,7 @@ const ThemeSwitch = () => {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="currentColor"
-        className="text-gray-100 dark:text-gray-100"
+        className="text-gray-700 dark:text-gray-100"
       >
         {mounted && (theme === 'dark' || resolvedTheme === 'dark') ? (
           <path

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -78,7 +78,7 @@ export default function ListLayout({
     <>
       <div>
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-100 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
             {title}
           </h1>
           <div className="relative max-w-lg">
@@ -89,7 +89,7 @@ export default function ListLayout({
                 type="text"
                 onChange={(e) => setSearchValue(e.target.value)}
                 placeholder="Search articles"
-                className="block w-full rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-gray-100 placeholder-gray-400 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-700 dark:bg-gray-800"
+                className="block w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
               />
             </label>
             <svg
@@ -116,13 +116,13 @@ export default function ListLayout({
             const { path, date, title, summary, tags } = post
             return (
               <li key={path}>
-                <article className="rounded-lg border border-gray-700 bg-gray-800/50 p-4 transition-all hover:border-gray-600 hover:bg-gray-800 sm:p-5">
+                <article className="rounded-lg border border-gray-200 bg-white/60 p-4 backdrop-blur-sm transition-all hover:border-gray-300 hover:bg-white/80 sm:p-5 dark:border-gray-700 dark:bg-gray-800/50 dark:hover:border-gray-600 dark:hover:bg-gray-800">
                   <div className="flex flex-col gap-2">
-                    <div className="flex flex-wrap items-center gap-2 text-sm text-gray-400">
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
                       <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
                       {tags.length > 0 && (
                         <>
-                          <span className="text-gray-600">•</span>
+                          <span className="text-gray-400 dark:text-gray-600">•</span>
                           <div className="flex flex-wrap gap-1">
                             {tags.map((tag) => (
                               <Tag key={tag} text={tag} />
@@ -134,13 +134,13 @@ export default function ListLayout({
                     <h3 className="text-lg font-semibold leading-tight sm:text-xl">
                       <Link
                         href={`/${path}`}
-                        className="text-gray-100 hover:text-primary-400 transition-colors"
+                        className="text-gray-900 hover:text-primary-500 transition-colors dark:text-gray-100 dark:hover:text-primary-400"
                       >
                         {title}
                       </Link>
                     </h3>
                     {summary && (
-                      <p className="line-clamp-2 text-sm text-gray-400 sm:text-base">
+                      <p className="line-clamp-2 text-sm text-gray-600 dark:text-gray-400 sm:text-base">
                         {summary}
                       </p>
                     )}

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -40,7 +40,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
     <SectionContainer>
       <BlogSEO url={`${siteMetadata.siteUrl}/${path}`} authorDetails={authorDetails} {...content} />
       <ScrollTopAndComment />
-      <article className="rounded-2xl border border-white/10 bg-black/50 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8">
+      <article className="rounded-2xl border border-gray-200/50 bg-white/60 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8 dark:border-white/10 dark:bg-black/50">
         <div className="xl:divide-y xl:divide-gray-200 xl:dark:divide-gray-700">
           <header className="pt-6 xl:pb-6">
             <div className="space-y-1 text-center">
@@ -77,7 +77,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                       )}
                       <dl className="whitespace-nowrap text-sm font-medium leading-5">
                         <dt className="sr-only">Name</dt>
-                        <dd className="text-gray-100 dark:text-gray-200">{author.name}</dd>
+                        <dd className="text-gray-900 dark:text-gray-200">{author.name}</dd>
                         <dt className="sr-only">Twitter</dt>
                         <dd>
                           {author.twitter && (

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -27,7 +27,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
     <SectionContainer>
       <BlogSEO url={`${siteMetadata.siteUrl}/${path}`} {...content} />
       <ScrollTopAndComment />
-      <article className="rounded-2xl border border-white/10 bg-black/50 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8">
+      <article className="rounded-2xl border border-gray-200/50 bg-white/60 px-4 py-6 backdrop-blur-md sm:px-6 md:px-8 md:py-8 dark:border-white/10 dark:bg-black/50">
         <div>
           <header>
             <div className="space-y-1 border-b border-gray-200 pb-10 text-center dark:border-gray-700">

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -26,7 +26,7 @@ class MyDocument extends Document {
           <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000" />
           <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
         </Head>
-        <body className="bg-white text-white antialiased dark:bg-gray-900 dark:text-white">
+        <body className="bg-white text-gray-900 antialiased dark:bg-gray-900 dark:text-white">
           <Main />
           <NextScript />
         </body>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,10 +24,10 @@ export default function Home({ posts }: InferGetStaticPropsType<typeof getStatic
       <PageSEO title={siteMetadata.title} description={siteMetadata.description} />
       <div>
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-100 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
             Latest
           </h1>
-          <p className="text-lg leading-7 text-gray-400 dark:text-gray-400">
+          <p className="text-lg leading-7 text-gray-600 dark:text-gray-400">
             {siteMetadata.description}
           </p>
         </div>
@@ -37,13 +37,13 @@ export default function Home({ posts }: InferGetStaticPropsType<typeof getStatic
             const { slug, date, title, summary, tags } = post
             return (
               <li key={slug}>
-                <article className="rounded-lg border border-gray-700 bg-gray-800/50 p-4 transition-all hover:border-gray-600 hover:bg-gray-800 sm:p-5">
+                <article className="rounded-lg border border-gray-200 bg-white/60 p-4 backdrop-blur-sm transition-all hover:border-gray-300 hover:bg-white/80 sm:p-5 dark:border-gray-700 dark:bg-gray-800/50 dark:hover:border-gray-600 dark:hover:bg-gray-800">
                   <div className="flex flex-col gap-2">
-                    <div className="flex flex-wrap items-center gap-2 text-sm text-gray-400">
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
                       <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
                       {tags.length > 0 && (
                         <>
-                          <span className="text-gray-600">•</span>
+                          <span className="text-gray-400 dark:text-gray-600">•</span>
                           <div className="flex flex-wrap gap-1">
                             {tags.map((tag) => (
                               <Tag key={tag} text={tag} />
@@ -55,13 +55,13 @@ export default function Home({ posts }: InferGetStaticPropsType<typeof getStatic
                     <h2 className="text-lg font-semibold leading-tight sm:text-xl">
                       <Link
                         href={`/blog/${slug}`}
-                        className="text-gray-100 hover:text-primary-400 transition-colors"
+                        className="text-gray-900 hover:text-primary-500 transition-colors dark:text-gray-100 dark:hover:text-primary-400"
                       >
                         {title}
                       </Link>
                     </h2>
                     {summary && (
-                      <p className="line-clamp-2 text-sm text-gray-400 sm:text-base">
+                      <p className="line-clamp-2 text-sm text-gray-600 dark:text-gray-400 sm:text-base">
                         {summary}
                       </p>
                     )}

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -26,13 +26,13 @@ export default function Projects() {
   return (
     <>
       <PageSEO title={`Projects - ${siteMetadata.author}`} description={siteMetadata.description} />
-      <div className="divide-y divide-gray-700 dark:divide-gray-700">
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
         {/* ヘッダー */}
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-100 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
             Projects
           </h1>
-          <p className="text-lg leading-7 text-gray-300 dark:text-gray-300">
+          <p className="text-lg leading-7 text-gray-600 dark:text-gray-300">
             ポートフォリオ一覧
           </p>
         </div>
@@ -50,7 +50,7 @@ export default function Projects() {
                     ${
                       activeCategory === category.id
                         ? 'bg-primary-500 text-white shadow-lg shadow-primary-500/25'
-                        : 'bg-gray-800/50 text-gray-300 hover:bg-gray-700/50 hover:text-white'
+                        : 'bg-gray-200/50 text-gray-600 hover:bg-gray-300/50 hover:text-gray-900 dark:bg-gray-800/50 dark:text-gray-300 dark:hover:bg-gray-700/50 dark:hover:text-white'
                     }
                   `}
                 >
@@ -62,7 +62,7 @@ export default function Projects() {
                         ${
                           activeCategory === category.id
                             ? 'bg-white/20 text-white'
-                            : 'bg-gray-700 text-gray-400'
+                            : 'bg-gray-300 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
                         }
                       `}
                     >

--- a/pages/tags.tsx
+++ b/pages/tags.tsx
@@ -26,10 +26,10 @@ export default function Tags({ tags }: InferGetStaticPropsType<typeof getStaticP
       <PageSEO title={`Tags - ${siteMetadata.author}`} description="Things I blog about" />
       <div className="mx-auto max-w-4xl">
         <div className="space-y-4 pt-6 pb-8 md:pt-12">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-100 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14">
             Tags
           </h1>
-          <p className="text-gray-400">
+          <p className="text-gray-500 dark:text-gray-400">
             {sortedTags.length} タグ・{Object.values(tags).reduce((a, b) => a + b, 0)} 記事
           </p>
         </div>
@@ -43,13 +43,13 @@ export default function Tags({ tags }: InferGetStaticPropsType<typeof getStaticP
             <Link
               key={t}
               href={`/tags/${kebabCase(t)}`}
-              className="group flex items-center gap-2 rounded-lg border border-gray-700/50 bg-gray-800/50 px-4 py-2.5 transition-all hover:border-primary-500/50 hover:bg-gray-800"
+              className="group flex items-center gap-2 rounded-lg border border-gray-200 bg-white/60 backdrop-blur-sm px-4 py-2.5 transition-all hover:border-primary-500/50 hover:bg-white/80 dark:border-gray-700/50 dark:bg-gray-800/50 dark:hover:bg-gray-800"
               aria-label={`View posts tagged ${t}`}
             >
-              <span className="text-sm font-medium text-gray-200 transition-colors group-hover:text-primary-400">
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-200 transition-colors group-hover:text-primary-400">
                 {t.split(' ').join('-')}
               </span>
-              <span className="rounded-full bg-gray-700/80 px-2 py-0.5 text-xs font-semibold text-gray-300 transition-colors group-hover:bg-primary-500/20 group-hover:text-primary-300">
+              <span className="rounded-full bg-gray-200 px-2 py-0.5 text-xs font-semibold text-gray-600 transition-colors group-hover:bg-primary-500/20 group-hover:text-primary-300 dark:bg-gray-700/80 dark:text-gray-300">
                 {tags[t]}
               </span>
             </Link>
@@ -60,7 +60,7 @@ export default function Tags({ tags }: InferGetStaticPropsType<typeof getStaticP
           <div className="mt-8">
             <button
               onClick={() => setShowAll(!showAll)}
-              className="rounded-lg border border-gray-700 bg-gray-800/50 px-5 py-2.5 text-sm font-medium text-gray-300 transition-all hover:border-gray-600 hover:bg-gray-800 hover:text-gray-100"
+              className="rounded-lg border border-gray-300 bg-white/60 px-5 py-2.5 text-sm font-medium text-gray-600 transition-all hover:border-gray-400 hover:bg-white/80 hover:text-gray-900 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-100"
             >
               {showAll
                 ? 'メインタグのみ表示'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,40 +34,51 @@ module.exports = {
         primary: colors.sky,
         gray: colors.neutral,
       },
+      keyframes: {
+        blob: {
+          '0%': { transform: 'translate(0px, 0px) scale(1)' },
+          '33%': { transform: 'translate(30px, -50px) scale(1.1)' },
+          '66%': { transform: 'translate(-20px, 20px) scale(0.9)' },
+          '100%': { transform: 'translate(0px, 0px) scale(1)' },
+        },
+      },
+      animation: {
+        blob: 'blob 8s ease-in-out infinite',
+      },
       typography: (theme) => ({
         DEFAULT: {
           css: {
-            color: theme('colors.gray.300'),
+            color: theme('colors.gray.700'),
             a: {
               color: theme('colors.primary.500'),
               '&:hover': {
-                color: `${theme('colors.primary.400')} !important`,
+                color: `${theme('colors.primary.600')} !important`,
               },
               code: { color: theme('colors.primary.400') },
             },
             h1: {
               fontWeight: '700',
               letterSpacing: theme('letterSpacing.tight'),
-              color: theme('colors.gray.100'),
+              color: theme('colors.gray.900'),
             },
             h2: {
               fontWeight: '700',
               letterSpacing: theme('letterSpacing.tight'),
-              color: theme('colors.gray.100'),
+              color: theme('colors.gray.900'),
             },
             h3: {
               fontWeight: '600',
-              color: theme('colors.gray.100'),
+              color: theme('colors.gray.900'),
             },
             'h4,h5,h6': {
-              color: theme('colors.gray.100'),
+              color: theme('colors.gray.900'),
             },
             pre: {
               backgroundColor: theme('colors.gray.800'),
             },
             code: {
-              color: theme('colors.pink.400'),
-              backgroundColor: theme('colors.gray.800'),
+              color: theme('colors.pink.500'),
+              backgroundColor: theme('colors.gray.100'),
               paddingLeft: '4px',
               paddingRight: '4px',
               paddingTop: '2px',
@@ -88,99 +99,30 @@ module.exports = {
               paddingBottom: '2px',
               borderRadius: '0.25rem',
             },
-            // code: {
-            //   backgroundColor: theme('colors.gray.800'),
-            // },
-            hr: { borderColor: theme('colors.gray.700') },
+            hr: { borderColor: theme('colors.gray.200') },
             'ol li::marker': {
               fontWeight: '600',
-              color: theme('colors.gray.400'),
+              color: theme('colors.gray.500'),
             },
             'ul li::marker': {
-              backgroundColor: theme('colors.gray.400'),
+              backgroundColor: theme('colors.gray.500'),
             },
-            strong: { color: theme('colors.gray.100') },
+            strong: { color: theme('colors.gray.600') },
             thead: {
               th: {
-                color: theme('colors.gray.100'),
+                color: theme('colors.gray.900'),
               },
             },
             tbody: {
               tr: {
-                borderBottomColor: theme('colors.gray.700'),
+                borderBottomColor: theme('colors.gray.200'),
               },
             },
             blockquote: {
-              color: theme('colors.gray.100'),
-              borderLeftColor: theme('colors.gray.700'),
+              color: theme('colors.gray.900'),
+              borderLeftColor: theme('colors.gray.200'),
             },
           },
-          // css: {
-          //   color: theme('colors.gray.700'),
-          //   a: {
-          //     color: theme('colors.primary.500'),
-          //     '&:hover': {
-          //       color: `${theme('colors.primary.600')} !important`,
-          //     },
-          //     code: { color: theme('colors.primary.400') },
-          //   },
-          //   h1: {
-          //     fontWeight: '700',
-          //     letterSpacing: theme('letterSpacing.tight'),
-          //     color: theme('colors.gray.900'),
-          //   },
-          //   h2: {
-          //     fontWeight: '700',
-          //     letterSpacing: theme('letterSpacing.tight'),
-          //     color: theme('colors.gray.900'),
-          //   },
-          //   h3: {
-          //     fontWeight: '600',
-          //     color: theme('colors.gray.900'),
-          //   },
-          //   'h4,h5,h6': {
-          //     color: theme('colors.gray.900'),
-          //   },
-          //   pre: {
-          //     backgroundColor: theme('colors.gray.800'),
-          //   },
-          //   code: {
-          //     color: theme('colors.pink.500'),
-          //     backgroundColor: theme('colors.gray.100'),
-          //     paddingLeft: '4px',
-          //     paddingRight: '4px',
-          //     paddingTop: '2px',
-          //     paddingBottom: '2px',
-          //     borderRadius: '0.25rem',
-          //   },
-          //   'code::before': {
-          //     content: 'none',
-          //   },
-          //   'code::after': {
-          //     content: 'none',
-          //   },
-          //   details: {
-          //     backgroundColor: theme('colors.gray.100'),
-          //     paddingLeft: '4px',
-          //     paddingRight: '4px',
-          //     paddingTop: '2px',
-          //     paddingBottom: '2px',
-          //     borderRadius: '0.25rem',
-          //   },
-          //   hr: { borderColor: theme('colors.gray.200') },
-          //   'ol li::marker': {
-          //     fontWeight: '600',
-          //     color: theme('colors.gray.500'),
-          //   },
-          //   'ul li::marker': {
-          //     backgroundColor: theme('colors.gray.500'),
-          //   },
-          //   strong: { color: theme('colors.gray.600') },
-          //   blockquote: {
-          //     color: theme('colors.gray.900'),
-          //     borderLeftColor: theme('colors.gray.200'),
-          //   },
-          // },
         },
         dark: {
           css: {
@@ -212,15 +154,6 @@ module.exports = {
             pre: {
               backgroundColor: theme('colors.gray.800'),
             },
-            // code: {
-            //   color: theme('colors.green.400'),
-            //   backgroundColor: theme('colors.gray.800'),
-            //   paddingLeft: '4px',
-            //   paddingRight: '4px',
-            //   paddingTop: '2px',
-            //   paddingBottom: '2px',
-            //   borderRadius: '0.25rem',
-            // },
             code: {
               color: theme('colors.green.400'),
               backgroundColor: theme('colors.gray.800'),
@@ -244,9 +177,6 @@ module.exports = {
               paddingBottom: '2px',
               borderRadius: '0.25rem',
             },
-            // code: {
-            //   backgroundColor: theme('colors.gray.800'),
-            // },
             hr: { borderColor: theme('colors.gray.700') },
             'ol li::marker': {
               fontWeight: '600',


### PR DESCRIPTION
- Replace matrix background with animated aurora gradient blobs in light mode
- Keep matrix rain effect for dark mode only
- Fix invisible text throughout (white text on white bg)
- Add proper light/dark mode variants to all components
- Fix typography plugin DEFAULT to use dark text colors for light mode
- Fix mobile nav, header, footer, tags, cards, project cards
- Fix search input, article cards, post layouts, donation section

https://claude.ai/code/session_01Ezj5xnmy6kfNjikYy6LThD